### PR TITLE
Fix pnpm i error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "packageManager": "pnpm@8.2.0",
+  "engines": {
+    "node": "18.x"
+  },
   "scripts": {
     "build": "next build",
     "dev": "next dev",


### PR DESCRIPTION
When attempting to run this project locally I ran into the following warning (for several packages) that results in an error after retries have been exhausted: `GET https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.3.0-canary.9.tgz error (ERR_INVALID_THIS). Will retry in 10 seconds. 2 retries left.`

After digging into the issue there was a mismatched between the pnpm version specified by the project and the node version I was using (v20). After switching to version 18 (v18.20.0), the error was resolved.

The error only occurs if one is downloading these packages for the first time: if they are already within someone pnpn store, then an error will not occur.

To reproduce:
pnpm store prune
made sure no node modules folder is present
nvm use 20 (I'm using v20.11.0 and assuming the issue will persist with different minor and patch versions)
pnpm i


If there is a better way to resolve the issue than provided, let me know or make the appropriate edits.