### PR TITLE
fix broken link

### DIFF
--- a/app/layouts/page.tsx
+++ b/app/layouts/page.tsx
@@ -15,7 +15,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts">
+        <ExternalLink href="https://nextjs.org/docs/app/getting-started/layouts-and-pages">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/layouts">


### PR DESCRIPTION
This pull request fixes invalid external link to Layout and Pages page from official documentation on route `/layouts`. [Old link](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts) vs [new link](https://nextjs.org/docs/app/getting-started/layouts-and-pages)